### PR TITLE
Delete index

### DIFF
--- a/wagtail/images/views/images.py
+++ b/wagtail/images/views/images.py
@@ -266,7 +266,7 @@ def delete(request, image_id):
         dependants = {
             m._meta: ii for m, ii in collector.data.items()
             if not issubclass(m, (AbstractRendition, image.__class__)) and
-            not isinstance(m, IndexEntry) and
+            not m is IndexEntry and
             not getattr(m, 'exclude_from_search_index', False)
         }
 

--- a/wagtail/images/views/images.py
+++ b/wagtail/images/views/images.py
@@ -15,6 +15,7 @@ from wagtail.admin import messages
 from wagtail.admin.auth import PermissionPolicyChecker, permission_denied
 from wagtail.admin.forms.search import SearchForm
 from wagtail.admin.models import popular_tags_for_model
+from wagtail.contrib.postgres_search.models import IndexEntry
 from wagtail.core.models import Collection, Site
 from wagtail.images import get_image_model
 from wagtail.images.exceptions import InvalidFilterSpecError
@@ -265,6 +266,7 @@ def delete(request, image_id):
         dependants = {
             m._meta: ii for m, ii in collector.data.items()
             if not issubclass(m, (AbstractRendition, image.__class__)) and
+            not issubclass(m, (IndexEntry, image.__class__)) and
             not getattr(m, 'exclude_from_search_index', False)
         }
 

--- a/wagtail/images/views/images.py
+++ b/wagtail/images/views/images.py
@@ -266,7 +266,7 @@ def delete(request, image_id):
         dependants = {
             m._meta: ii for m, ii in collector.data.items()
             if not issubclass(m, (AbstractRendition, image.__class__)) and
-            not issubclass(m, (IndexEntry, image.__class__)) and
+            not isinstance(m, IndexEntry) and
             not getattr(m, 'exclude_from_search_index', False)
         }
 


### PR DESCRIPTION
Since we started using wagtails pg search backend, our search index is now stored in the DB. Some forked code prevents deletion of objects with dependent objects. This commit adds a short circuit if that dependent is a pg search index object (because deletion of an object should cascade to it's search index entry.)